### PR TITLE
chore: Update callback code to use id_token

### DIFF
--- a/src/components/callback/Callback.tsx
+++ b/src/components/callback/Callback.tsx
@@ -17,7 +17,7 @@ export const Callback: React.FC<{ setAccessToken: Function }> = ({
   useEffect(
     () => {
       const parsedHash = queryString.parse(history.location.hash);
-      const { access_token, state } = parsedHash;
+      const { state, id_token } = parsedHash;
       // Context: https://auth0.com/docs/protocols/state-parameters
       if (!isAccessTokenValid(state as string)) {
         setErrorMessage(
@@ -25,7 +25,7 @@ export const Callback: React.FC<{ setAccessToken: Function }> = ({
         Sent State: ${getAccessTokenState()}, Returned State: ${state}`
         );
       }
-      setAccessToken(access_token);
+      setAccessToken(id_token);
       history.push("/");
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
chore: Update callback code to use id_token instead of access_token since latest FHIR server now requires id_token for auth

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
