### PR TITLE
Fix a dependency issue that will cause deployment error.

### DIFF
--- a/amplify-infra/package.json
+++ b/amplify-infra/package.json
@@ -11,19 +11,19 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.100.0",
+    "@aws-cdk/assert": "1.137.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "1.100.0",
+    "aws-cdk": "1.137.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-amplify": "^1.100.0",
-    "@aws-cdk/aws-codecommit": "^1.100.0",
-    "@aws-cdk/core": "1.100.0",
+    "@aws-cdk/aws-amplify": "^1.137.0",
+    "@aws-cdk/aws-codecommit": "^1.137.0",
+    "@aws-cdk/core": "1.137.0",
     "source-map-support": "^0.5.16"
   },
   "resolutions": {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/fhir-works-on-aws-deployment/issues/565

*Description of changes:*
Changed the version dependency from 1.100.0 to 1.137.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
